### PR TITLE
update function exchange_code in Auth provider Facebook for 2.x

### DIFF
--- a/classes/PHPixie/Auth/Login/Facebook.php
+++ b/classes/PHPixie/Auth/Login/Facebook.php
@@ -201,8 +201,7 @@ class Facebook extends Provider {
 				."&client_secret={$this->app_secret}"
 				."&code={$code}";
 		$response = $this->request($url);
-		parse_str($response, $params);
-		return $params;
+		return json_decode($response, true);
 	}
 	
 	/**


### PR DESCRIPTION
Because response format was changed and now it became JSON:
{"access_token":"EAAkq23456495JAAJKFHDLkjh9sdy8fsd98fLHJKDFJK8Y0e4Ypwrqo4tMZD","token_type":"bearer","expires_in":5179867}

 This fix is now really needed to work.